### PR TITLE
feat: #519 select symbol and convert to ts

### DIFF
--- a/src/app/utils/defines.tsx
+++ b/src/app/utils/defines.tsx
@@ -1,0 +1,32 @@
+// Supported Investment Coins Configuration
+
+const baseSymbolList = [
+  { symbol: "BTC/USDT", base: "USDT", quote: "BTC" },
+  { symbol: "ETH/USDT", base: "USDT", quote: "ETH" },
+  { symbol: "EOS/USDT", base: "USDT", quote: "EOS" },
+  { symbol: "LTC/USDT", base: "USDT", quote: "LTC" },
+  { symbol: "ETC/USDT", base: "USDT", quote: "ETC" }
+];
+
+export const fetchExchangeSymbolList = (exchange) => {
+  if(!exchange) {
+    return baseSymbolList;
+  }
+  let ownSymbolList = [];
+  if(exchange === 'binance') {
+    ownSymbolList = [
+      { symbol: "BCC/USDT", base: "USDT", quote: "BCC" }
+    ];
+  } else if(exchange === 'huobipro') {
+    ownSymbolList = [
+      { symbol: "BCH/USDT", base: "USDT", quote: "BCC" },
+      { symbol: "CMT/USDT", base: "USDT", quote: "CMT" },
+      { symbol: "IOST/USDT", base: "USDT", quote: "IOST" }
+    ];
+  }else{
+    ownSymbolList = [
+      { symbol: "BCH/USDT", base: "USDT", quote: "BCH" }
+    ];
+  }
+  return baseSymbolList.concat(ownSymbolList);
+}


### PR DESCRIPTION
feat(new strategy): handle symbol selection and convert js to ts 

This PR includes the following changes:
- 【JavaScript Handling for Symbols】 Symbols are fetched from utils/defines.tsx and then displayed on new strategy page. Functionality were added for users to click on a symbol to store it in the state.
- 【Conversion to ts】 Converted strategy/new/page.jsx to strategy/new/page.tsx for improved type safety and maintainability.


