### PR TITLE
fix: standardize HTTP client usage and fix API paths

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,11 +2,11 @@
 'use client';
 
 import React, { useState, useEffect, useRef, ChangeEvent } from 'react';
-import axios from 'axios';
 import { getInvalidFields, validateField } from '../../utils/validator';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import auth from '../../utils/auth';
+import HTTP from '@/lib/http';
 import { css } from '@emotion/react';
 import Alert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
@@ -26,7 +26,10 @@ const SignUp = () => {
   const [captchaSrc, setCaptchaSrc] = useState('');
   const [invalidFields, setInvalidFields] = useState<InvalidFields>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [alertMessage, setAlertMessage] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [alertMessage, setAlertMessage] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
   const [open, setOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -96,7 +99,7 @@ const SignUp = () => {
 
   // handle Captcha picture
   const updateCaptcha = async () => {
-    const response = await axios.get('/api/v1/captcha?');
+    const response = await HTTP.get('/v1/captcha');
     setCaptchaSrc(response.data);
   };
 
@@ -124,9 +127,9 @@ const SignUp = () => {
     }
     setIsSubmitting(true);
     try {
-      const response = await axios.post('/api/v1/auth/signup', formData);
+      const response = await HTTP.post('/v1/auth/signup', formData);
       setIsSubmitting(false);
-      const data = response.data.data;
+      const data = response.data;
       const userId = data?._id;
       const email = data?.email;
       setAlertMessage({ type: 'success', message: 'Successful registration, quick activation.' });
@@ -135,7 +138,7 @@ const SignUp = () => {
         router.push(`/activate/${userId}?email=${encodeURIComponent(email)}`);
       }, 2000);
     } catch (error: any) {
-      const errorMessage = error.response?.data?.message ;
+      const errorMessage = error?.message;
       setAlertMessage({ type: 'error', message: errorMessage });
       setOpen(true);
       setIsSubmitting(false);
@@ -145,7 +148,7 @@ const SignUp = () => {
   const handleClose = () => {
     setOpen(false);
   };
-  
+
   return (
     <div css={signUpStyle}>
       <Snackbar
@@ -188,7 +191,11 @@ const SignUp = () => {
                         <i className="fa fa-user"></i>
                       </span>
                     </div>
-                    {invalidFields.name && <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.name}</p>}
+                    {invalidFields.name && (
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.name}
+                      </p>
+                    )}
                   </div>
                   <div className="field">
                     <div className="control has-icons-left has-icons-right">
@@ -208,7 +215,11 @@ const SignUp = () => {
                         <i className="fa fa-envelope"></i>
                       </span>
                     </div>
-                    {invalidFields.email && <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.email}</p>}
+                    {invalidFields.email && (
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.email}
+                      </p>
+                    )}
                   </div>
                   <div className="field">
                     <div className="control has-icons-left has-icons-right">
@@ -234,13 +245,20 @@ const SignUp = () => {
                         role="button"
                         tabIndex={0}
                         aria-label={showPassword ? '隐藏密码' : '显示密码'}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setShowPassword(!showPassword); } }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setShowPassword(!showPassword);
+                          }
+                        }}
                       >
                         <i className={`fa ${showPassword ? 'fa-eye' : 'fa-eye-slash'}`}></i>
                       </span>
                     </div>
                     {invalidFields.password && (
-                      <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.password}</p>
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.password}
+                      </p>
                     )}
                   </div>
                   <div className="field">
@@ -267,13 +285,20 @@ const SignUp = () => {
                         role="button"
                         tabIndex={0}
                         aria-label={showConfirmPassword ? '隐藏密码' : '显示密码'}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setShowConfirmPassword(!showConfirmPassword); } }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            setShowConfirmPassword(!showConfirmPassword);
+                          }
+                        }}
                       >
                         <i className={`fa ${showConfirmPassword ? 'fa-eye' : 'fa-eye-slash'}`}></i>
                       </span>
                     </div>
                     {invalidFields.confirmPassword && (
-                      <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.confirmPassword}</p>
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.confirmPassword}
+                      </p>
                     )}
                   </div>
                   <div className="field">
@@ -295,7 +320,9 @@ const SignUp = () => {
                       </span>
                     </div>
                     {invalidFields.refCode && (
-                      <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.refCode}</p>
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.refCode}
+                      </p>
                     )}
                   </div>
                   <div className="field">
@@ -317,17 +344,26 @@ const SignUp = () => {
                       <div
                         className="control"
                         style={{ cursor: 'pointer' }}
-                        dangerouslySetInnerHTML={{ __html: captchaSrc }} /* SVG captcha from own API */
+                        dangerouslySetInnerHTML={{
+                          __html: captchaSrc,
+                        }} /* SVG captcha from own API */
                         title={t('prompt.click_refresh_captcha')}
                         aria-label="验证码，点击刷新"
                         role="button"
                         tabIndex={0}
                         onClick={updateCaptcha}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); updateCaptcha(); } }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            updateCaptcha();
+                          }
+                        }}
                       />
                     </div>
                     {invalidFields.captcha && (
-                      <p className="help is-danger" role="alert" aria-live="polite">{invalidFields.captcha}</p>
+                      <p className="help is-danger" role="alert" aria-live="polite">
+                        {invalidFields.captcha}
+                      </p>
                     )}
                   </div>
                   <div className="field" style={{ marginTop: '30px' }}>
@@ -335,7 +371,8 @@ const SignUp = () => {
                       <button
                         className={`button is-link is-fullwidth is-focused ${isSubmitting ? 'is-loading' : ''}`}
                         onClick={handleSignUp}
-                        disabled={isSubmitting}>
+                        disabled={isSubmitting}
+                      >
                         {t('sign_up')}
                       </button>
                     </p>
@@ -419,7 +456,6 @@ const signUpStyle = css`
   .feature {
     padding: 5rem;
   }
-
 
   .card-footer-item {
     font-size: 12px;

--- a/src/app/ucenter/invite/page.tsx
+++ b/src/app/ucenter/invite/page.tsx
@@ -4,13 +4,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import axios from 'axios';
 import { format } from 'date-fns';
 import { css } from '@emotion/react';
 import Image from 'next/image';
 import { QRCodeCanvas } from 'qrcode.react';
 import { useTranslation } from 'react-i18next';
 import auth from '@/utils/auth';
+import HTTP from '@/lib/http';
 import Skeleton from '@/components/Skeleton';
 import no_record from '@/assets/images/no_record.png';
 
@@ -209,8 +209,9 @@ const posterContentStyle = css`
   background: #438dec;
   text-align: center;
   box-sizing: border-box;
-  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC',
-    'Microsoft YaHei', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Microsoft YaHei',
+    sans-serif;
   position: absolute;
   left: -9999px;
   top: 0;
@@ -352,20 +353,14 @@ export default function InvitePage() {
 
     async function fetchData() {
       try {
-        const token = auth.getToken();
-        const headers: Record<string, string> = {};
-        if (token) headers.token = token;
-        if (localUser._id) headers.user_id = localUser._id;
-
         const [userRes, invitationsRes] = await Promise.all([
-          axios.get(`/api/v1/users/${userId}`, { headers }),
-          axios.get(`/api/v1/users/${userId}`, {
-            headers,
+          HTTP.get(`/v1/users/${userId}`),
+          HTTP.get(`/v1/users/${userId}`, {
             params: { invitations: true },
           }),
         ]);
 
-        const userData = userRes.data?.data;
+        const userData = userRes.data;
         if (userData) {
           const code = userData.invitation_code || '';
           setInviteCode(code);
@@ -378,7 +373,7 @@ export default function InvitePage() {
           }
         }
 
-        const invitationData = invitationsRes.data?.data;
+        const invitationData = invitationsRes.data;
         if (invitationData?.invitations) {
           setInviteList(invitationData.invitations);
         }
@@ -448,7 +443,7 @@ export default function InvitePage() {
         </span>
       ) : (
         <span key={i}>{part}</span>
-      ),
+      )
     );
   }
 
@@ -592,18 +587,10 @@ export default function InvitePage() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={posterImg} alt="Invite Poster" onClick={(e) => e.stopPropagation()} />
           <div className="poster-actions" onClick={(e) => e.stopPropagation()}>
-            <a
-              href={posterImg}
-              download={`moow_invite_${inviteCode}`}
-              className="button is-info"
-            >
+            <a href={posterImg} download={`moow_invite_${inviteCode}`} className="button is-info">
               {t('invite.poster_save')}
             </a>
-            <button
-              type="button"
-              className="button is-light"
-              onClick={() => setShowPoster(false)}
-            >
+            <button type="button" className="button is-light" onClick={() => setShowPoster(false)}>
               {t('action.cancel')}
             </button>
           </div>

--- a/src/app/ucenter/profile/page.tsx
+++ b/src/app/ucenter/profile/page.tsx
@@ -120,7 +120,7 @@ export default function ProfilePage() {
   const handleLogout = async () => {
     if (!window.confirm(t('prompt.confirm_logout'))) return;
     try {
-      await HTTP.post('/api/v1/auth/logout');
+      await HTTP.post('/v1/auth/logout');
     } catch {
       // ignore logout API errors
     }
@@ -129,9 +129,7 @@ export default function ProfilePage() {
     router.push('/');
   };
 
-  const isVipActive = user?.vip_time_out_at
-    ? new Date(user.vip_time_out_at) > new Date()
-    : false;
+  const isVipActive = user?.vip_time_out_at ? new Date(user.vip_time_out_at) > new Date() : false;
 
   if (loading) {
     return (
@@ -211,9 +209,7 @@ export default function ProfilePage() {
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setNickName(e.target.value)}
               />
             </div>
-            {invalidFields.nick_name && (
-              <p className="help is-danger">{invalidFields.nick_name}</p>
-            )}
+            {invalidFields.nick_name && <p className="help is-danger">{invalidFields.nick_name}</p>}
           </div>
 
           <div className="field is-grouped action-buttons">


### PR DESCRIPTION
## Summary
- Fix logout API path in profile page (was `/api/v1/auth/logout`, should be `/v1/auth/logout` since HTTP client baseURL already includes `/api`)
- Replace direct `axios` usage with centralized `HTTP` client in signup page
- Replace direct `axios` usage with centralized `HTTP` client in invite page
- All pages now benefit from automatic token injection, error handling, and CSRF protection

## Test plan
- [x] `npm run lint` passes (no new errors)
- [x] Build type error is pre-existing (fund/page.tsx Highcharts types), not caused by these changes
- [ ] Manual test: logout from profile page works
- [ ] Manual test: signup flow works
- [ ] Manual test: invite page loads user data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)